### PR TITLE
Fallback to XML element indices when getting the coordinates for a cell

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/OneCloudInc/xlsx/v3
 go 1.15
 
 require (
-	golang.org/x/text v0.3.3
 	github.com/frankban/quicktest v1.11.2
 	github.com/google/btree v1.0.0 // indirect
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
@@ -11,5 +10,6 @@ require (
 	github.com/pkg/profile v1.5.0
 	github.com/rogpeppe/fastuuid v1.2.0
 	github.com/shabbyrobe/xmlwriter v0.0.0-20200208144257-9fca06d00ffa
+	golang.org/x/text v0.3.3 // indirect
 	gopkg.in/check.v1 v1.0.0-20200902074654-038fdea0a05b
 )

--- a/go.sum
+++ b/go.sum
@@ -11,7 +11,6 @@ github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
-github.com/peterbourgon/diskv v1.0.0 h1:bRU92KzrX3TQ6IYobfie/PnZkFC+1opBfHpf/PHPDoo=
 github.com/peterbourgon/diskv v2.0.1+incompatible h1:UBdAOUP5p4RWqPBg048CAvpKN+vxiaj6gdUUzhl4XmI=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/pkg/profile v1.5.0 h1:042Buzk+NhDI+DeSAA62RwJL8VAuZUMQZUjCsRz1Mug=

--- a/lib_test.go
+++ b/lib_test.go
@@ -237,7 +237,64 @@ func TestLib(t *testing.T) {
 		worksheet := new(xlsxWorksheet)
 		err := xml.NewDecoder(sheetxml).Decode(worksheet)
 		c.Assert(err, qt.IsNil)
-		minx, miny, maxx, maxy, err := calculateMaxMinFromWorksheet(worksheet)
+		minx, miny, maxx, maxy := calculateMaxMinFromWorksheet(worksheet)
+		c.Assert(err, qt.IsNil)
+		c.Assert(minx, qt.Equals, 0)
+		c.Assert(miny, qt.Equals, 0)
+		c.Assert(maxx, qt.Equals, 1)
+		c.Assert(maxy, qt.Equals, 1)
+	})
+
+	c.Run("GetRangeFromString", func(c *qt.C) {
+		var rangeString string
+		var lower, upper int
+		var err error
+		rangeString = "1:3"
+		lower, upper, err = getRangeFromString(rangeString)
+		c.Assert(err, qt.IsNil)
+		c.Assert(lower, qt.Equals, 1)
+		c.Assert(upper, qt.Equals, 3)
+	})
+
+	c.Run("CalculateMaxMinFromWorksheet - no cell id", func(c *qt.C) {
+		var sheetxml = bytes.NewBufferString(`
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"
+           xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+           xmlns:mx="http://schemas.microsoft.com/office/mac/excel/2008/main"
+           xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+           xmlns:mv="urn:schemas-microsoft-com:mac:vml"
+           xmlns:x14="http://schemas.microsoft.com/office/spreadsheetml/2009/9/main"
+           xmlns:x14ac="http://schemas.microsoft.com/office/spreadsheetml/2009/9/ac"
+           xmlns:xm="http://schemas.microsoft.com/office/excel/2006/main">
+  <sheetViews>
+    <sheetView workbookViewId="0"/>
+  </sheetViews>
+  <sheetFormatPr customHeight="1" defaultColWidth="14.43" defaultRowHeight="15.75"/>
+  <sheetData>
+    <row r="1">
+      <c t="s" s="1" r="">
+        <v>0</v>
+      </c>
+      <c t="s" s="1" r="">
+        <v>1</v>
+      </c>
+    </row>
+    <row r="2">
+      <c t="s" s="1" r="">
+        <v>2</v>
+      </c>
+      <c t="s" s="1" r="">
+        <v>3</v>
+      </c>
+    </row>
+  </sheetData>
+  <drawing r:id="rId1"/>
+</worksheet>`)
+		worksheet := new(xlsxWorksheet)
+		err := xml.NewDecoder(sheetxml).Decode(worksheet)
+		c.Assert(err, qt.IsNil)
+		minx, miny, maxx, maxy := calculateMaxMinFromWorksheet(worksheet)
 		c.Assert(err, qt.IsNil)
 		c.Assert(minx, qt.Equals, 0)
 		c.Assert(miny, qt.Equals, 0)


### PR DESCRIPTION
Ensures that when calculating the min and max cells for a sheet we fallback to the indices of the rows and cells.